### PR TITLE
[Docs] Correct minor mistake in basic-features/pages.md

### DIFF
--- a/pages/docs/basic-features/pages.md
+++ b/pages/docs/basic-features/pages.md
@@ -6,7 +6,7 @@ authors:
 
 # Pages
 
-In Aleph.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported as **default** from a `.js`, `.tsx`, `.ts`, `.tsx`, `.mjs` file in the `pages` directory. Each page is associated with a route based on its file name.
+In Aleph.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported as **default** from a `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs` file in the `pages` directory. Each page is associated with a route based on its file name.
 
 **Example**: If you create `pages/about.tsx` that exports a React component like below, it will be accessible at `/about`.
 


### PR DESCRIPTION
`.tsx` is repeated twice, whereas it was meant to show `.jsx` too among the other examples of file extensions.