### PR TITLE
Change sass-loader plugin path

### DIFF
--- a/pages/docs/basic-features/built-in-css-support.md
+++ b/pages/docs/basic-features/built-in-css-support.md
@@ -80,7 +80,7 @@ To add a global stylesheet to your application, import the CSS files within `app
 Aleph.js provide a `sass-loader` plugin allows you import `sass` files, to use the plugin please update the `aleph.config.js`:
 
 ```javascript
-import sass from 'https://deno.land/x/aleph@0.2.19/plugins/sass.ts'
+import sass from 'https://deno.land/x/aleph/plugins/sass.ts'
 
 export default {
     plugins: [sass, ...],


### PR DESCRIPTION
url path `https://deno.land/x/aleph@0.2.19/plugins/sass.ts` seems not working and making confusion for new comer 
, either change to latest version of sass plugin or stick with current version with url below.

`https://deno.land/x/aleph@v0.2.19/plugins/sass.ts`