### PR TITLE
Change installation URL to the latest version

### DIFF
--- a/pages/docs/get-started.md
+++ b/pages/docs/get-started.md
@@ -19,7 +19,7 @@ If you're new to Aleph.js you should check out the [about](/docs/) page.
 ## Installation
 
 ```bash
-$ deno install --unstable -A -f -n aleph https://deno.land/x/aleph@v0.2.28/cli.ts
+$ deno install --unstable -A -f -n aleph https://deno.land/x/aleph/cli.ts
 ```
 
 ## Usage


### PR DESCRIPTION
The old doc pin the version number to 0.2.28, I think it is not necessary. Since aleph.js is still in alpha dev process, I would like to purpose this change to let people can install the latest version of it. 