### PR TITLE
Removed import statements on markdown files

### DIFF
--- a/routes/docs/basic-concepts/server.md
+++ b/routes/docs/basic-concepts/server.md
@@ -4,8 +4,6 @@ authors:
   - ije
 ---
 
-import { Link } from "aleph/react"
-
 # Server
 
 In Aleph.js, the server handles all incoming requests, everything is

--- a/routes/docs/index.md
+++ b/routes/docs/index.md
@@ -5,8 +5,6 @@ authors:
   - razermoon
 ---
 
-import { Link } from "aleph/react"
-
 # Aleph.js
 
 **Aleph.js** (or **Aleph** or **א** or **阿莱夫**, <samp>ˈɑːlɛf</samp>) is a


### PR DESCRIPTION
There were some import statements being displayed on the docs. It looks like we should remove it, so I did. 
Hope that was right.